### PR TITLE
Introduce a proof of concept publish_later functionality

### DIFF
--- a/beetle.gemspec
+++ b/beetle.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",           ">= 2.3.4"
 
   s.add_development_dependency "activerecord",        "~> 5.0"
+  s.add_development_dependency "byebug"
   s.add_development_dependency "cucumber",            "~> 2.4.0"
   s.add_development_dependency "daemon_controller",   "~> 1.2.0"
   s.add_development_dependency "daemons",             ">= 1.2.0"

--- a/examples/attempts_with_dlx_and_explicit_exceptions.rb
+++ b/examples/attempts_with_dlx_and_explicit_exceptions.rb
@@ -1,0 +1,73 @@
+# attempts_with_dead_letter_and_exponential_backoff.rb
+# ! check the examples/README.rdoc for information on starting your redis/rabbit !
+#
+# start it with ruby attempts_with_dead_letter_and_exponential_backoff.rb
+
+require "rubygems"
+require File.expand_path("../lib/beetle", File.dirname(__FILE__))
+
+require 'byebug'
+
+# set Beetle log level to info, less noisy than debug
+Beetle.config.logger.level = Logger::INFO
+
+# setup client with dead lettering enabled
+config = Beetle::Configuration.new
+config.dead_lettering_enabled = true
+config.dead_lettering_msg_ttl = 1000 # millis
+client = Beetle::Client.new(config)
+client.register_queue(:test)
+client.register_message(:test)
+
+# purge the test queue
+client.purge(:test)
+
+# empty the dedup store
+client.deduplication_store.flushdb
+
+# setup our counter
+$completed = 0
+$exceptions_limit = 4
+
+# store the start time
+$start_time = Time.now.to_f
+
+ReenqueueError = Class.new(StandardError)
+
+# declare a handler class for deferred/delayed message processing
+class Handler < Beetle::Handler
+  def process
+    logger.info message.data
+    $completed += 1
+
+    delay = (1..4).to_a.sample
+    message.instance_variable_set(:@delay, delay)
+    message.set_delay!
+    logger.info "Attempts: #{message.attempts}, next delay: #{message.delay}, Processed at: #{Time.now.to_f - $start_time}"
+
+    raise ReenqueueError, "dedicated error to trigger retry"
+  end
+end
+client.register_handler(:test, Handler, on_exceptions: [ReenqueueError], exceptions: $exceptions_limit)
+
+puts "Published 1 test message now to DEFERRED queue: #{Time.now.to_f}"
+client.publish(:test, {foo: :whatever})
+
+
+# start the listening loop
+client.listen do
+  # catch INT-signal and stop listening
+  trap("INT") { client.stop_listening }
+  # we're adding a periodic timer to check whether all 10 messages have been processed without exceptions
+  timer = EM.add_periodic_timer(1) do
+    if $completed == $exceptions_limit + 1
+      timer.cancel
+      client.stop_listening
+    end
+  end
+end
+
+puts "Handled #{$completed} messages"
+if $completed != $exceptions_limit + 1
+  raise "Did not handle the correct number of messages"
+end

--- a/examples/attempts_with_dlx_delayed_execution.rb
+++ b/examples/attempts_with_dlx_delayed_execution.rb
@@ -1,0 +1,70 @@
+# attempts_with_dead_letter_and_exponential_backoff.rb
+# ! check the examples/README.rdoc for information on starting your redis/rabbit !
+#
+# start it with ruby attempts_with_dead_letter_and_exponential_backoff.rb
+
+require "rubygems"
+require File.expand_path("../lib/beetle", File.dirname(__FILE__))
+
+require 'byebug'
+
+# set Beetle log level to info, less noisy than debug
+Beetle.config.logger.level = Logger::INFO
+
+# setup client with dead lettering enabled
+config = Beetle::Configuration.new
+config.dead_lettering_enabled = true
+config.dead_lettering_msg_ttl = 1000 # millis
+client = Beetle::Client.new(config)
+client.register_queue(:test)
+client.register_message(:test)
+client.register_message(:test_dead_letter)
+
+# purge the test queue
+client.purge(:test)
+
+# empty the dedup store
+client.deduplication_store.flushdb
+
+# setup our counter
+$completed = 0
+
+# store the start time
+$start_time = Time.now.to_f
+
+ReenqueueError = Class.new(StandardError)
+
+# declare a handler class for deferred/delayed message processing
+class Handler < Beetle::Handler
+  def process
+    logger.info "Attempts: #{message.attempts}, Defer: #{message.defer}, Processed after: #{Time.now.to_f - $start_time}"
+    logger.info message.data
+    $completed += 1
+  end
+end
+# for WORK QUEUE
+client.register_handler(:test, Handler)
+
+puts "Published 1 test message now to DEFERRED queue: #{Time.now.to_f}"
+client.publish(:test_dead_letter, {foo: :late}, headers: {defer: 6})
+client.publish(:test_dead_letter, {foo: :early}, headers: {defer: 3})
+
+#client.publish_at(:test, {foo: :bar}, 6.seconds.from_now) # should look like this
+
+# start the listening loop
+client.listen do
+  # catch INT-signal and stop listening
+  trap("INT") { client.stop_listening }
+  # we're adding a periodic timer to check whether all 10 messages have been processed without exceptions
+  timer = EM.add_periodic_timer(1) do
+    if $completed == 2
+      timer.cancel
+      client.stop_listening
+    end
+  end
+end
+
+puts "Handled #{$completed} messages"
+if $completed != 2
+  raise "Did not handle the correct number of messages"
+end

--- a/lib/beetle/dead_lettering.rb
+++ b/lib/beetle/dead_lettering.rb
@@ -47,7 +47,7 @@ module Beetle
         "apply-to" => "queues",
         "definition" => {
           "dead-letter-routing-key" => dead_letter_routing_key(queue_name, options),
-          "dead-letter-exchange" => ""
+          "dead-letter-exchange" => dead_letter_exchange(options),
         }
       }
 
@@ -67,6 +67,10 @@ module Beetle
 
     def dead_letter_routing_key(queue_name, options)
       options.fetch(:routing_key) { dead_letter_queue_name(queue_name) }
+    end
+
+    def dead_letter_exchange(options)
+      options.fetch(:exchange) { "" }
     end
 
     def dead_letter_queue_name(queue_name)

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -235,7 +235,7 @@ module Beetle
       @store.get(msg_id, :exceptions).to_i > exceptions_limit
     end
 
-    def exception_registered?
+    def exception_accepted?
       on_exceptions.nil? || @exception.class.in?(on_exceptions)
     end
 
@@ -281,7 +281,12 @@ module Beetle
         Beetle::reraise_expectation_errors!
         logger.warn "Beetle: exception '#{e}' during processing of message #{msg_id}"
         logger.warn "Beetle: backtrace: #{e.backtrace.join("\n")}"
-        result = RC::InternalError
+        result = 
+        
+        
+        
+        
+        ::InternalError
       end
       result
     end
@@ -371,11 +376,11 @@ module Beetle
         ack!
         logger.debug "Beetle: reached the handler exceptions limit: #{exceptions_limit} on #{msg_id}"
         RC::ExceptionsLimitReached
-      elsif !exception_registered?
+      elsif !exception_accepted?
         completed!
         ack!
-        logger.debug "Beetle: `#{@exception.class.name}` not included in `on_exceptions` (#{on_exceptions.join(',')}) on #{msg_id}"
-        RC::ExceptionNotRegistered
+        logger.debug "Beetle: `#{@exception.class.name}` not accepted on #{msg_id} (`on_exceptions` is set with #{on_exceptions.join(',')})"
+        RC::ExceptionNotAccepted
       else
         delete_mutex!
         timed_out!

--- a/lib/beetle/r_c.rb
+++ b/lib/beetle/r_c.rb
@@ -30,6 +30,8 @@ module Beetle
     rc :Ancient
     rc :AttemptsLimitReached, :failure
     rc :ExceptionsLimitReached, :failure
+    rc :ExceptionNotRegistered, :failure
+    rc :Deferred, :reject
     rc :Delayed, :reject
     rc :HandlerCrash, :reject
     rc :HandlerNotYetTimedOut, :reject

--- a/lib/beetle/r_c.rb
+++ b/lib/beetle/r_c.rb
@@ -30,7 +30,7 @@ module Beetle
     rc :Ancient
     rc :AttemptsLimitReached, :failure
     rc :ExceptionsLimitReached, :failure
-    rc :ExceptionNotRegistered, :failure
+    rc :ExceptionNotAccepted, :failure
     rc :Deferred, :reject
     rc :Delayed, :reject
     rc :HandlerCrash, :reject


### PR DESCRIPTION
I try to get a dynamic per message delay. something like enqueue_at/process_at/publish_later with a number of seconds or a time when processing is done at the earliest.

Both attempt_* files implement a way to get that working (very hacky yet) with slight differences on how exactly the task is performed (*exception based* or with a new *beetle message attribute* 'defer').
However, both are client side solutions (afaics being triggered by rabbitmq server every 1000ms = dead_letter_message_ttl which is a global queue ttl)  and the beetle client does or does not delay/defer the execution based on a value (the per message-ttl) in the redis store.

But there are server side solutions ('message-ttl' or 'expiration') in rabbitmq (http://www.rabbitmq.com/ttl.html#per-message-ttl-in-publishers) but it looks like they are not supported in these client versions (beetle and bunny) and maybe not in our rabbitmq version at xing. 
Newer bunny versions at least introduce the per message-ttl explicitly as 'expiration' in the MessageProperties class.

I tried to fumble  'expiration' and 'message-ttl' through bunny just to see a different behaviour from the server side yet to no avail, now I couldn't quite figure out how to investigate further


UPDATE: in bunny https://github.com/ruby-amqp/bunny/blob/v0.7.11/lib/bunny/exchange09.rb#L148 we can add an 'expiration' param in millis that works as a server side per message-ttl (at least in my test)